### PR TITLE
HiperDex | Domain change

### DIFF
--- a/src/HiperDex/HiperDex.ts
+++ b/src/HiperDex/HiperDex.ts
@@ -9,10 +9,10 @@ import {
     Madara
 } from '../Madara'
 
-const DOMAIN = 'https://1sthiperdex.com'
+const DOMAIN = 'https://hiperdex.com'
 
 export const HiperDexInfo: SourceInfo = {
-    version: getExportVersion('0.0.2'),
+    version: getExportVersion('0.0.3'),
     name: 'HiperDex',
     description: `Extension that pulls manga from ${DOMAIN}`,
     author: 'GameFuzzy',


### PR DESCRIPTION
Canonical name was changed back to `hiperdex.com`
`1sthiperdex.com` seems to 301 you back to `hiperdex.com` but those redirects may or may not be causing issues within the app.