### PR TITLE
Fix malformed url parsing

### DIFF
--- a/src/Madara.ts
+++ b/src/Madara.ts
@@ -25,7 +25,7 @@ import {
     sourceSettings
 } from './MadaraSettings'
 
-const BASE_VERSION = '2.2.5'
+const BASE_VERSION = '2.2.6'
 export const getExportVersion = (EXTENSION_VERSION: string): string => {
     return BASE_VERSION.split('.').map((x, index) => Number(x) + Number(EXTENSION_VERSION.split('.')[index])).join('.')
 }

--- a/src/MadaraParser.ts
+++ b/src/MadaraParser.ts
@@ -109,7 +109,6 @@ export class Parser {
             if (!page) {
                 throw new Error(`Could not parse page for ${mangaId}/${chapterId}`)
             }
-
             pages.push(encodeURI(await page))
         }
 
@@ -264,6 +263,11 @@ export class Parser {
                     .replace('-350x476', '')
             }
         }
+
+        // Malforumed url fix (Turns https:///example.com into https://example.com (or the http:// equivalent))
+        image = image?.replace(/https:\/\/\//g, 'https://') // only changes urls with https protocol
+        image = image?.replace(/http:\/\/\//g, 'http://') // only changes urls with http protocol
+
         return decodeURI(this.decodeHTMLEntity(image?.trim() ?? ''))
     }
 


### PR DESCRIPTION
Check and fix urls that are parsed with three forward slahes instead of two (e.g. https:///example.com turns into https://example.com) Example of this use case can be seen at https://manhuaus.com/manga/its-over-empress-husband-is-actually-invincible/chapter-28/ (the first image has it's data-src attribute be https:///cdn.manhuaus.com/madara/2023-04-14/8884899366438cbffa57714.48601788.jpg in the html file)